### PR TITLE
Add additional error handling

### DIFF
--- a/src/ghs.ts
+++ b/src/ghs.ts
@@ -18,6 +18,10 @@ export async function request(
         ? await axios.default.get(url, config)
         : await axios.default.post(url, {query: query}, config);
 
+    if (response.errors) {
+      console.error(`API failure: ${response.errors[0].message}`);
+      process.exit(1);
+    }
     if (response.data.error) {
       console.error(`API failure: ${response.data.error}`);
       process.exit(1);


### PR DESCRIPTION
---
name: 🐞 Bug Fix
about: You found a bug
labels: bug

---

## Description

I had difficulty figuring out the correct permissions required for the GitHub token to run this locally and I noticed that the script would error without showing the error message from the API response. This PR adds an additional error handler which is triggered if, for example, you use a GitHub token which does not have the `read:org` permission.

## Example

```
> ghsvg

API failure: Your token has not been granted the required scopes to execute this query. The 'email' field requires one of the following scopes: ['user:email', 'read:user'], but your token has only been granted the: ['read:org', 'repo'] scopes. Please modify your token's scopes at: https://github.com/settings/tokens.
```