### PR TITLE
Remove unnecessary fields from the organisation query

### DIFF
--- a/src/ghs.ts
+++ b/src/ghs.ts
@@ -18,6 +18,10 @@ export async function request(
         ? await axios.default.get(url, config)
         : await axios.default.post(url, {query: query}, config);
 
+    if (response.errors) {
+      console.error(`API failure: ${response.errors[0].message}`);
+      process.exit(1);
+    }
     if (response.data.error) {
       console.error(`API failure: ${response.data.error}`);
       process.exit(1);

--- a/src/ghs.ts
+++ b/src/ghs.ts
@@ -90,6 +90,13 @@ export async function getAccountFragment(
       ) {
         return;
       }
+      const fieldsToRemove = [
+        'membersCanForkPrivateRepositories',
+        'webCommitSignoffRequired',
+      ]
+      if (fieldsToRemove.includes(field.name)) {
+        return;
+      }
       return field.name;
     })
     .filter(Boolean);


### PR DESCRIPTION
---
name: 🐞 Bug Fix
about: You found a bug
labels: bug

---

## Description

This PR extends #1 and removes two fields from the organisation query that my user for some reason does not have permission to access. Prior to this change my sponsors SVG image was missing 4 sponsors. I honestly don't know why, but this fixes it.

## Error messages that this avoids

```
> ghsvg

API failure: johnbillion does not have the right permission to view membersCanForkPrivateRepositories.
```

```
> ghsvg

API failure: johnbillion does not have the right permission to view webCommitSignoffRequired.
```